### PR TITLE
fixed synonym hover state and white line above source url

### DIFF
--- a/src/assets/styles/Result.scss
+++ b/src/assets/styles/Result.scss
@@ -95,6 +95,13 @@ $meaning-synonyms-example-color: #838383;
             .synonyms{
                 color: $phonetics-synonyms-color;
                 font-weight: 500;
+                &:hover{
+                    text-decoration: underline;
+                    text-decoration-thickness: 1.3px;
+                    text-underline-offset: 2px;
+                    text-decoration-color: #A445ED;
+                    cursor: pointer;
+                }
             }
             a{
                 text-decoration: none;
@@ -115,7 +122,8 @@ $meaning-synonyms-example-color: #838383;
     .link-span{
         justify-content: flex-start;
         gap: 20px;
-        margin-top: 0;
+        border-top: 2px solid rgba(117, 117, 117, 0.1);
+        margin-top: 40px;
         padding-top: 0;
         align-items: center;
         display: flex;

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -64,7 +64,6 @@ export const Result: React.FC<resultProps> = ({ result, loading }) => {
                                   </div>
                               ))}
                           </div>
-                          <hr />
                           <span className="link-span">
                               <h5 id="source-word">Source</h5>
                               <span className="url">


### PR DESCRIPTION
Fixed a UI issue. synonyms hover state and white line above source url change to required colour